### PR TITLE
fix: Reset values on asset category change

### DIFF
--- a/exam_frontend/src/components/AddAsset/AddAsset.tsx
+++ b/exam_frontend/src/components/AddAsset/AddAsset.tsx
@@ -233,10 +233,25 @@ const AddAsset: React.FC = ({
     }
   };
   const handleResetForm = () => {
-    setFormData({}); // Clear the form data
-    setResetForm(true); // Trigger reset
+    setFormData({});
+    setResetForm(true);
+    setassettypeValue("");
+    setValue("");
+    setLicenseValue("");
+    setOwnerValue("");
+    setAssetLocation("");
+    setAssetBu("");
+    setModelNumber("");
+    setOs("");
+    setOsVersion("");
+    setMobileOs("");
+    setProcessor("");
+    setProcessorGen("");
+    setMemory("");
+    setStorage("");
+
     setTimeout(() => {
-      setResetForm(false); // Reset the trigger after a short delay
+      setResetForm(false);
     }, 100);
   };
 
@@ -472,6 +487,7 @@ const AddAsset: React.FC = ({
                 displayEmpty
                 onChange={(event) => {
                   setAssetCategoryValue(event.target.value as string);
+                  handleResetForm();
                   setFormData({
                     ...formData,
                     asset_category: event.target.value as string,

--- a/exam_frontend/src/components/Tooltip/Tooltip.tsx
+++ b/exam_frontend/src/components/Tooltip/Tooltip.tsx
@@ -9,6 +9,7 @@ const ToolTip: React.FC<TooltipProps> = ({ title, children }) => (
     title={title}
     placement="top"
     TransitionComponent={Zoom}
+    disableInteractive
   >
     {children}
   </Tooltip>


### PR DESCRIPTION
## Description

Reset values of all fields on asset category change when creating a new asset.

Fixes #388 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
