### PR TITLE
feat: Add prop to disable autocomplete box used in "Add Asset" and "Modify Asset" drawers

### DIFF
--- a/exam_frontend/src/components/AutocompleteBox/AssetFieldAutoComplete.tsx
+++ b/exam_frontend/src/components/AutocompleteBox/AssetFieldAutoComplete.tsx
@@ -26,11 +26,12 @@ import { getUserOptions } from "./api/getUserDetails";
 
 const filter = createFilterOptions();
 
-interface Props{
-  assetField?:any;
-  value?:any;
-  setValue?:any;
-  defaultValue?:any;
+interface Props {
+  assetField?: any;
+  value?: any;
+  setValue?: any;
+  defaultValue?: any;
+  isDisabled?: boolean;
 }
 
 const AssetFieldAutoComplete = ({
@@ -38,6 +39,7 @@ const AssetFieldAutoComplete = ({
   value,
   setValue,
   defaultValue,
+  isDisabled = false,
 }: Props) => {
   const [open, toggleOpen] = React.useState(false);
 
@@ -170,6 +172,7 @@ const AssetFieldAutoComplete = ({
       {foreignFieldValueNames.includes(assetField) && (
         <React.Fragment>
           <Autocomplete
+            disabled={isDisabled}
             value={value}
             loading={isAssetDataLoading}
             onChange={(event, newValue, reason) => {
@@ -282,6 +285,7 @@ const AssetFieldAutoComplete = ({
 
       {!foreignFieldValueNames.includes(assetField) && (
         <Autocomplete
+          disabled={isDisabled}
           value={value}
           loading={isAssetDataLoading}
           freeSolo={!["product_name", "owner"].includes(assetFieldKeyName())}

--- a/exam_frontend/src/components/CardComponent/CardComponent.tsx
+++ b/exam_frontend/src/components/CardComponent/CardComponent.tsx
@@ -451,8 +451,13 @@ const CardComponent: React.FC<CardType> = ({
       label: "Product Name",
       name: "productName",
       value: (
-        <Form.Item name="product name" rules={[{ required: true, message: 'Product Name is required' }]}>
-          <b>Product Name: <span style={{ color: 'red' }}>*</span></b>
+        <Form.Item
+          name="product name"
+          rules={[{ required: true, message: "Product Name is required" }]}
+        >
+          <b>
+            Product Name: <span style={{ color: "red" }}>*</span>
+          </b>
           <br></br>
           <br></br>
           <AssetFieldAutoComplete
@@ -467,8 +472,14 @@ const CardComponent: React.FC<CardType> = ({
     {
       label: "Asset Category",
       value: (
-        <Form.Item name="assetCategory" rules={[{ required: true, message: 'Asset Category is required' }]}>
-          <b style={{ display: "block" }}>Asset Category: <span style={{ color: 'red' }}>*</span></b> <br></br>
+        <Form.Item
+          name="assetCategory"
+          rules={[{ required: true, message: "Asset Category is required" }]}
+        >
+          <b style={{ display: "block" }}>
+            Asset Category: <span style={{ color: "red" }}>*</span>
+          </b>{" "}
+          <br></br>
           <Select
             id="simple-select-modify-category"
             label="Asset Category"
@@ -559,8 +570,14 @@ const CardComponent: React.FC<CardType> = ({
       label: "Serial Number",
       name: "serialNumber",
       value: (
-        <Form.Item name="serial number" rules={[{ required: true, message: 'Serial Number is required' }]}>
-          <b>Serial Number: <span style={{ color: 'red' }}>*</span></b> <br></br>
+        <Form.Item
+          name="serial number"
+          rules={[{ required: true, message: "Serial Number is required" }]}
+        >
+          <b>
+            Serial Number: <span style={{ color: "red" }}>*</span>
+          </b>{" "}
+          <br></br>
           <br></br>
           <TextField
             id="outlined-textarea-serial-hardware-modify"
@@ -640,8 +657,15 @@ const CardComponent: React.FC<CardType> = ({
       label: "Location",
       name: "location",
       value: (
-        <Form.Item name="location" className="formItem" rules={[{ required: true, message: 'Location is required' }]}>
-          <b> Asset Location: <span style={{ color: 'red' }}>*</span></b>
+        <Form.Item
+          name="location"
+          className="formItem"
+          rules={[{ required: true, message: "Location is required" }]}
+        >
+          <b>
+            {" "}
+            Asset Location: <span style={{ color: "red" }}>*</span>
+          </b>
           <br></br>
           <br></br>
           <AssetFieldAutoComplete
@@ -657,8 +681,13 @@ const CardComponent: React.FC<CardType> = ({
       label: "Invoice Location",
       name: "invoice location",
       value: (
-        <Form.Item name="location" rules={[{ required: true, message: 'Invoice Location is required' }]}>
-          <b>Invoice Location: <span style={{ color: 'red' }}>*</span></b>
+        <Form.Item
+          name="location"
+          rules={[{ required: true, message: "Invoice Location is required" }]}
+        >
+          <b>
+            Invoice Location: <span style={{ color: "red" }}>*</span>
+          </b>
           <br></br>
           <br></br>
           <AssetFieldAutoComplete
@@ -674,8 +703,14 @@ const CardComponent: React.FC<CardType> = ({
       label: "Date of Purchase",
       name: "dateOfPurchase",
       value: (
-        <Form.Item name="date of purchase" rules={[{ required: true, message: 'Date of Purchase is required' }]}>
-          <b>Date of Purchase: <span style={{ color: 'red' }}>*</span></b> <br></br>
+        <Form.Item
+          name="date of purchase"
+          rules={[{ required: true, message: "Date of Purchase is required" }]}
+        >
+          <b>
+            Date of Purchase: <span style={{ color: "red" }}>*</span>
+          </b>{" "}
+          <br></br>
           <br></br>
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker


### PR DESCRIPTION
## Description

Add prop to disable autocomplete box used in "Add Asset" and "Modify Asset" drawers

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
