### PR TITLE
fix: Persist the query even if the advanced query drawer is closed

### DIFF
--- a/exam_frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/exam_frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -23,20 +23,24 @@ export const QueryBuilderComponent: React.FC<
   const [selectedFields, setSelectedFields] = useState<
     { field: string; value: string; id: number }[]
   >([]);
-  const [newFields, setNewFields] = useState<number[]>([]);
+  const [newFields, setNewFields] = useState<string[]>([]);
   const initialState = { selectedFields: [], newFields: [] };
   const [filterValue, setFilterValue] = useState<number | string>();
   const [suggestion, setSuggestion] = useState<string[]>([]);
 
   const handleAddField = () => {
-    setNewFields((prev) => [...prev, prev.length]);
+    setNewFields((prev) => [
+      ...prev,
+      `id-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+    ]);
     setSelectedFields((prev) => [...prev, { field: "", value: "" }]);
     setSuggestion([]);
   };
 
-  const handleRemoveField = (index: number) => {
-    setNewFields((prev) => prev.filter((_, i) => i !== index));
+  const handleRemoveField = (currentEle, index: number) => {
+    setNewFields((prev) => prev.filter((ele) => ele !== currentEle));
     setSelectedFields((prev) => prev.filter((_, i) => i !== index));
+    setAllFieldValues((prev) => prev.filter((_, i) => i !== index));
   };
 
   const [allFieldValues, setAllFieldValues] = React.useState<
@@ -105,9 +109,9 @@ export const QueryBuilderComponent: React.FC<
     <div>
       <div>
         <div style={{ display: "flex", flexDirection: "column" }}>
-          {newFields.map((_, index) => (
+          {newFields.map((currentEle, index) => (
             <div
-              key={index}
+              key={currentEle}
               style={{
                 marginBottom: "10px",
                 display: "flex",
@@ -115,12 +119,12 @@ export const QueryBuilderComponent: React.FC<
               }}
             >
               <MuiAutocomplete
-                key={index}
+                key={currentEle}
                 allFieldValues={allFieldValues}
                 setAllFieldValues={setAllFieldValues}
               />
               <IconButton
-                onClick={() => handleRemoveField(index)}
+                onClick={() => handleRemoveField(currentEle, index)}
                 aria-label="remove"
                 size="large"
               >

--- a/exam_frontend/src/pages/RequestPage/DrawerViewRequest.tsx
+++ b/exam_frontend/src/pages/RequestPage/DrawerViewRequest.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Drawer } from "antd";
-import type { DrawerProps} from "antd";
+import type { DrawerProps } from "antd";
 
 interface DrawerViewRequestProps extends DrawerProps {
   title?: string;
@@ -19,13 +19,7 @@ const DrawerViewRequest: FC<DrawerViewRequestProps> = ({
 }) => {
   return (
     <>
-      <Drawer
-        destroyOnClose={true}
-        title={title}
-        onClose={onClose}
-        open={open}
-        width={1200}
-      >
+      <Drawer title={title} onClose={onClose} open={open} width={1200}>
         {children}
       </Drawer>
     </>


### PR DESCRIPTION
## Description

Persist the built query even when the Advanced Search Drawer is closed so that the user can continue building the query if he/she wants to. In order to remove the built query, click on the "Reset" button.

Fixes #396

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
